### PR TITLE
Updates to fix build errors in other packages

### DIFF
--- a/include/point_cloud_transport/publisher.hpp
+++ b/include/point_cloud_transport/publisher.hpp
@@ -42,8 +42,6 @@
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
-#include "pluginlib/class_loader.hpp"
-
 #include <point_cloud_transport/loader_fwds.hpp>
 #include <point_cloud_transport/single_subscriber_publisher.hpp>
 

--- a/include/point_cloud_transport/subscriber.hpp
+++ b/include/point_cloud_transport/subscriber.hpp
@@ -42,8 +42,6 @@
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
-#include "pluginlib/class_loader.hpp"
-
 #include <point_cloud_transport/loader_fwds.hpp>
 #include <point_cloud_transport/transport_hints.hpp>
 

--- a/src/publisher.cpp
+++ b/src/publisher.cpp
@@ -37,6 +37,8 @@
 #include <utility>
 #include <vector>
 
+#include "pluginlib/class_loader.hpp"
+
 #include "rclcpp/expand_topic_or_service_name.hpp"
 #include "rclcpp/logging.hpp"
 #include "rclcpp/node.hpp"

--- a/src/subscriber.cpp
+++ b/src/subscriber.cpp
@@ -36,6 +36,7 @@
 #include <string>
 #include <vector>
 
+#include <pluginlib/class_loader.hpp>
 #include <pluginlib/exceptions.hpp>
 
 #include "rclcpp/expand_topic_or_service_name.hpp"


### PR DESCRIPTION
Because pluginlib is linked as PRIVATE, some usages by external packages were experiencing "include not found" errors when building.