### PR TITLE
Fixed param name

### DIFF
--- a/point_cloud_transport/include/point_cloud_transport/simple_publisher_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/simple_publisher_plugin.hpp
@@ -106,8 +106,15 @@ public:
     rcl_interfaces::msg::ParameterDescriptor())
   {
     if (simple_impl_) {
+      // Declare Parameters
+      uint ns_len = simple_impl_->node_->get_effective_namespace().length();
+      std::string param_base_name = getTopic().substr(ns_len);
+      std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+
+      std::string param_name = param_base_name + "." + parameter_name;
+
       simple_impl_->node_->template declare_parameter<T>(
-        parameter_name, value, parameter_descriptor);
+        param_name, value, parameter_descriptor);
       return true;
     }
     return false;


### PR DESCRIPTION
This should fix the parameters naming

for example draco expose `encode_speed` and `decode_speed`. But if you have several topic publishing data, you might have collisions. This should "namespace" the parameter:

 - `<topic_name>.encode_speed`
 - `<topic_name>.decode_speed`

for example:

 - `pct.point_cloud.draco.encode_speed`
 - `pct.point_cloud.draco.decode_speed`