### PR TITLE
Fixed draco subscriber parameter names

### DIFF
--- a/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
@@ -96,7 +96,6 @@ public:
     if (impl_) {
       uint ns_len = impl_->node_->get_effective_namespace().length();
       std::string param_base_name = getTopic().substr(ns_len);
-      std::cout << "param_base_name " << param_base_name << std::endl;
       std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
       std::string param_name = param_base_name + "." + parameter_name;

--- a/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
@@ -88,10 +88,23 @@ public:
   }
 
   template<typename T>
-  bool declareParam(const std::string parameter_name, const T value)
+  bool declareParam(
+    const std::string parameter_name, const T value,
+    const rcl_interfaces::msg::ParameterDescriptor & parameter_descriptor =
+    rcl_interfaces::msg::ParameterDescriptor())
   {
     if (impl_) {
-      impl_->node_->template declare_parameter<T>(parameter_name, value);
+      uint ns_len = impl_->node_->get_effective_namespace().length();
+      std::string param_base_name = getTopic().substr(ns_len);
+      std::cout << "param_base_name " << param_base_name << std::endl;
+      std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+
+      std::string param_name = param_base_name + "." + parameter_name;
+
+      rcl_interfaces::msg::ParameterDescriptor param_descriptor = parameter_descriptor;
+      param_descriptor.name = param_name;
+
+      impl_->node_->template declare_parameter<T>(param_name, value, param_descriptor);
       return true;
     }
     return false;

--- a/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
@@ -103,7 +103,12 @@ public:
       rcl_interfaces::msg::ParameterDescriptor param_descriptor = parameter_descriptor;
       param_descriptor.name = param_name;
 
-      impl_->node_->template declare_parameter<T>(param_name, value, param_descriptor);
+      try {
+        impl_->node_->template declare_parameter<T>(param_name, value, param_descriptor);
+      } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
+        RCLCPP_DEBUG(impl_->node_->get_logger(), "%s was previously declared", param_descriptor.name.c_str());
+      }
+
       return true;
     }
     return false;

--- a/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
@@ -106,7 +106,9 @@ public:
       try {
         impl_->node_->template declare_parameter<T>(param_name, value, param_descriptor);
       } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
-        RCLCPP_DEBUG(impl_->node_->get_logger(), "%s was previously declared", param_descriptor.name.c_str());
+        RCLCPP_DEBUG(
+          impl_->node_->get_logger(), "%s was previously declared",
+          param_descriptor.name.c_str());
       }
 
       return true;


### PR DESCRIPTION
Superseed this PR https://github.com/ros-perception/point_cloud_transport_plugins/pull/37

The subscriber param names:

```bash
pct.point_cloud1.draco.skipDequantizationColor
pct.point_cloud1.draco.skipDequantization...
pct.point_cloud1.draco.skipDequantization...
pct.point_cloud1.draco.skipDequantization...
...
pct.point_cloud2.draco.skipDequantizationColor
pct.point_cloud2.draco.skipDequantization...
pct.point_cloud2.draco.skipDequantization...
pct.point_cloud2.draco.skipDequantization...
```