### PR TITLE
Add in dependency on python3-dev.

### DIFF
--- a/point_cloud_transport_py/package.xml
+++ b/point_cloud_transport_py/package.xml
@@ -18,6 +18,8 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
+  <build_depend>python3-dev</build_depend>
+
   <depend>point_cloud_transport</depend>
   <depend>pybind11_vendor</depend>
   <depend>pluginlib</depend>


### PR DESCRIPTION
We need this because we call find_package(Python3 Development) in our CMakeLists.txt here.

Also see https://github.com/ros2/ros2_tracing/pull/146#issuecomment-2492724725 for a long explanation of why we need this.