### PR TITLE
fix: add `rclcpp::shutdown`

### DIFF
--- a/point_cloud_transport/test/test_single_subscriber_publisher.cpp
+++ b/point_cloud_transport/test/test_single_subscriber_publisher.cpp
@@ -59,6 +59,11 @@ protected:
     node.reset();
   }
 
+  static void TearDownTestSuite()
+  {
+    rclcpp::shutdown();
+  }
+
   rclcpp::Node::SharedPtr node;
 };
 


### PR DESCRIPTION
This PR adds the forgetting `rclcpp::shutdown`.
