### PR TITLE
Deprecated rmw_qos_profile_t

### DIFF
--- a/point_cloud_transport/include/point_cloud_transport/point_cloud_transport.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/point_cloud_transport.hpp
@@ -129,6 +129,24 @@ Publisher create_publisher(
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
   const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions());
 
+/// \brief Advertise every available transport on pointcloud topics, free function version.
+/// \param node_interfaces the ROS node interfaces required for core node functionality, including
+///    NodeBaseInterface, NodeParametersInterface, NodeTopicsInterface, and NodeLoggingInterface.
+/// \param base_topic The base topic for the publisher
+/// \param custom_qos The QoS profile to use for the underlying publisher(s)
+/// \param options The publisher options to use for the underlying publisher(s)
+/// \return The advertised publisher
+POINT_CLOUD_TRANSPORT_PUBLIC
+Publisher create_publisher(
+  std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+    rclcpp::node_interfaces::NodeBaseInterface,
+    rclcpp::node_interfaces::NodeParametersInterface,
+    rclcpp::node_interfaces::NodeTopicsInterface,
+    rclcpp::node_interfaces::NodeLoggingInterface>> & node_interfaces,
+  const std::string & base_topic,
+  rclcpp::QoS custom_qos,
+  const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions());
+
 /// \brief Subscribe to a pointcloud transport topic, free function version.
 /// \param node The ROS node to use for any ROS operations
 /// \param base_topic The base topic for the sbuscription
@@ -167,6 +185,28 @@ Subscriber create_subscription(
   const Subscriber::Callback & callback,
   const std::string & transport,
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
+  rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions());
+
+/// \brief Subscribe to a pointcloud transport topic, free function version.
+/// \param node_interfaces the ROS node interfaces required for core node functionality, including
+///    NodeBaseInterface, NodeParametersInterface, NodeTopicsInterface, and NodeLoggingInterface.
+/// \param base_topic The base topic for the sbuscription
+/// \param callback The callback to invoke on receipt of a message
+/// \param transport The transport to use for the subscription
+/// \param custom_qos The QoS profile to use for the underlying publisher
+/// \param options The publisher options to use for the underlying publisher
+/// \return The subscriber
+POINT_CLOUD_TRANSPORT_PUBLIC
+Subscriber create_subscription(
+  std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+    rclcpp::node_interfaces::NodeBaseInterface,
+    rclcpp::node_interfaces::NodeParametersInterface,
+    rclcpp::node_interfaces::NodeTopicsInterface,
+    rclcpp::node_interfaces::NodeLoggingInterface>> & node_interfaces,
+  const std::string & base_topic,
+  const Subscriber::Callback & callback,
+  const std::string & transport,
+  rclcpp::QoS custom_qos,
   rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions());
 
 class PointCloudTransport : public PointCloudTransportLoader
@@ -212,8 +252,8 @@ public:
     uint32_t queue_size)
   {
     rclcpp::PublisherOptions options = rclcpp::PublisherOptions();
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_sensor_data;
-    custom_qos.depth = queue_size;
+    auto custom_qos = rclcpp::SensorDataQoS();
+    custom_qos.keep_last(queue_size);
     return Publisher(node_interfaces_, base_topic, pub_loader_, custom_qos, options);
   }
 
@@ -224,15 +264,26 @@ public:
     uint32_t queue_size,
     const rclcpp::PublisherOptions & options)
   {
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_sensor_data;
-    custom_qos.depth = queue_size;
+    auto custom_qos = rclcpp::SensorDataQoS();
+    custom_qos.keep_last(queue_size);
     return Publisher(node_interfaces_, base_topic, pub_loader_, custom_qos, options);
+  }
+
+  [[deprecated("Use advertise(..., rclcpp::QoS custom_qos, ...) instead")]]
+  POINT_CLOUD_TRANSPORT_PUBLIC
+  Publisher advertise(
+    const std::string & base_topic,
+    rmw_qos_profile_t custom_qos,
+    const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions())
+  {
+    return Publisher(node_interfaces_, base_topic, pub_loader_,
+        rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
   }
 
   POINT_CLOUD_TRANSPORT_PUBLIC
   Publisher advertise(
     const std::string & base_topic,
-    rmw_qos_profile_t custom_qos,
+    rclcpp::QoS custom_qos,
     const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions())
   {
     return Publisher(node_interfaces_, base_topic, pub_loader_, custom_qos, options);
@@ -259,9 +310,26 @@ public:
   //  const ros::VoidPtr& tracked_object = {}, bool latch = false);
 
   //! Subscribe to a point cloud topic, version for arbitrary std::function object.
+  [[deprecated("Use subscribe(..., rclcpp::QoS custom_qos, ...) instead")]]
   POINT_CLOUD_TRANSPORT_PUBLIC
   point_cloud_transport::Subscriber subscribe(
     const std::string & base_topic, rmw_qos_profile_t custom_qos,
+    const std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &)> & callback,
+    const VoidPtr & tracked_object = {},
+    const point_cloud_transport::TransportHints * transport_hints = nullptr,
+    rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
+  {
+    (void)tracked_object;
+    return Subscriber(
+      node_interfaces_, base_topic, callback, sub_loader_,
+      getTransportOrDefault(transport_hints),
+        rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+  }
+
+  //! Subscribe to a point cloud topic, version for arbitrary std::function object.
+  POINT_CLOUD_TRANSPORT_PUBLIC
+  point_cloud_transport::Subscriber subscribe(
+    const std::string & base_topic, rclcpp::QoS custom_qos,
     const std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &)> & callback,
     const VoidPtr & tracked_object = {},
     const point_cloud_transport::TransportHints * transport_hints = nullptr,
@@ -282,15 +350,29 @@ public:
     const point_cloud_transport::TransportHints * transport_hints = nullptr,
     rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
   {
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_sensor_data;
-    custom_qos.depth = queue_size;
+    rclcpp::QoS custom_qos = rclcpp::SensorDataQoS();
+    custom_qos.keep_last(queue_size);
     return subscribe(
       base_topic, custom_qos, callback, tracked_object, transport_hints, options);
   }
 
+  [[deprecated("Use subscribe(..., rclcpp::QoS custom_qos, ...) instead")]]
   POINT_CLOUD_TRANSPORT_PUBLIC
   point_cloud_transport::Subscriber subscribe(
     const std::string & base_topic, rmw_qos_profile_t custom_qos,
+    void (* fp)(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &),
+    const point_cloud_transport::TransportHints * transport_hints = nullptr,
+    rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
+  {
+    return subscribe(
+      base_topic, rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos),
+      std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &)>(fp),
+      VoidPtr(), transport_hints, options);
+  }
+
+  POINT_CLOUD_TRANSPORT_PUBLIC
+  point_cloud_transport::Subscriber subscribe(
+    const std::string & base_topic, rclcpp::QoS custom_qos,
     void (* fp)(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &),
     const point_cloud_transport::TransportHints * transport_hints = nullptr,
     rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
@@ -316,8 +398,24 @@ public:
 
   //! Subscribe to a point cloud topic, version for class member function with bare pointer.
   template<class T>
+  [[deprecated("Use subscribe(..., rclcpp::QoS custom_qos, ...) instead")]]
   point_cloud_transport::Subscriber subscribe(
     const std::string & base_topic, rmw_qos_profile_t custom_qos,
+    void (T::* fp)(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &) const, T * obj,
+    const point_cloud_transport::TransportHints * transport_hints = nullptr,
+    rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
+  {
+    return subscribe(
+      base_topic, rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos),
+        std::bind(
+        fp,
+        obj, std::placeholders::_1), VoidPtr(), transport_hints, options);
+  }
+
+  //! Subscribe to a point cloud topic, version for class member function with bare pointer.
+  template<class T>
+  point_cloud_transport::Subscriber subscribe(
+    const std::string & base_topic, rclcpp::QoS custom_qos,
     void (T::* fp)(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &) const, T * obj,
     const point_cloud_transport::TransportHints * transport_hints = nullptr,
     rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
@@ -343,8 +441,25 @@ public:
 
   //! Subscribe to a point cloud topic, version for class member function with shared_ptr.
   template<class T>
+  [[deprecated("Use subscribe(..., rclcpp::QoS custom_qos, ...) instead")]]
   point_cloud_transport::Subscriber subscribe(
     const std::string & base_topic, rmw_qos_profile_t custom_qos,
+    void (T::* fp)(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &) const,
+    const std::shared_ptr<T> & obj,
+    const point_cloud_transport::TransportHints * transport_hints = nullptr,
+    const rclcpp::SubscriptionOptions & options = rclcpp::SubscriptionOptions())
+  {
+    return subscribe(
+      base_topic, rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos),
+        std::bind(
+        fp,
+        obj, std::placeholders::_1), obj, transport_hints, options);
+  }
+
+  //! Subscribe to a point cloud topic, version for class member function with shared_ptr.
+  template<class T>
+  point_cloud_transport::Subscriber subscribe(
+    const std::string & base_topic, rclcpp::QoS custom_qos,
     void (T::* fp)(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &) const,
     const std::shared_ptr<T> & obj,
     const point_cloud_transport::TransportHints * transport_hints = nullptr,

--- a/point_cloud_transport/include/point_cloud_transport/point_cloud_transport.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/point_cloud_transport.hpp
@@ -118,6 +118,7 @@ Publisher create_publisher(
 /// \param custom_qos The QoS profile to use for the underlying publisher(s)
 /// \param options The publisher options to use for the underlying publisher(s)
 /// \return The advertised publisher
+[[deprecated("Use create_subscription(rclcpp::node_interfaces...) instead")]]
 POINT_CLOUD_TRANSPORT_PUBLIC
 Publisher create_publisher(
   std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
@@ -174,6 +175,7 @@ Subscriber create_subscription(
 /// \param custom_qos The QoS profile to use for the underlying publisher
 /// \param options The publisher options to use for the underlying publisher
 /// \return The subscriber
+[[deprecated("Use create_subscription(rclcpp::node_interfaces...) instead")]]
 POINT_CLOUD_TRANSPORT_PUBLIC
 Subscriber create_subscription(
   std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<

--- a/point_cloud_transport/include/point_cloud_transport/point_cloud_transport.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/point_cloud_transport.hpp
@@ -118,7 +118,7 @@ Publisher create_publisher(
 /// \param custom_qos The QoS profile to use for the underlying publisher(s)
 /// \param options The publisher options to use for the underlying publisher(s)
 /// \return The advertised publisher
-[[deprecated("Use create_subscription(rclcpp::node_interfaces...) instead")]]
+[[deprecated("Use create_subscription(rclcpp::node_interfaces..., rclcpp::QoS, ...) instead")]]
 POINT_CLOUD_TRANSPORT_PUBLIC
 Publisher create_publisher(
   std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
@@ -175,7 +175,7 @@ Subscriber create_subscription(
 /// \param custom_qos The QoS profile to use for the underlying publisher
 /// \param options The publisher options to use for the underlying publisher
 /// \return The subscriber
-[[deprecated("Use create_subscription(rclcpp::node_interfaces...) instead")]]
+[[deprecated("Use create_subscription(rclcpp::node_interfaces..., rclcpp::QoS, ...) instead")]]
 POINT_CLOUD_TRANSPORT_PUBLIC
 Subscriber create_subscription(
   std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<

--- a/point_cloud_transport/include/point_cloud_transport/publisher.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/publisher.hpp
@@ -70,9 +70,11 @@ public:
         rclcpp::node_interfaces::NodeParametersInterface,
         rclcpp::node_interfaces::NodeTopicsInterface,
         rclcpp::node_interfaces::NodeLoggingInterface>>(*node),
-      base_topic, loader, custom_qos, options)
+      base_topic, loader, rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos),
+      options)
   {}
 
+  [[deprecated("Use Publisher(rclcpp::node_interfaces, ..., rclcpp::QoS custom_qos,...) instead")]]
   POINT_CLOUD_TRANSPORT_PUBLIC
   Publisher(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
@@ -83,6 +85,18 @@ public:
     const std::string & base_topic,
     PubLoaderPtr loader,
     rmw_qos_profile_t custom_qos,
+    const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions());
+
+  POINT_CLOUD_TRANSPORT_PUBLIC
+  Publisher(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+    const std::string & base_topic,
+    PubLoaderPtr loader,
+    rclcpp::QoS custom_qos,
     const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions());
 
   //! get total number of subscribers to all advertised topics.

--- a/point_cloud_transport/include/point_cloud_transport/publisher_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/publisher_plugin.hpp
@@ -74,6 +74,7 @@ public:
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
     const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions());
 
+  [[deprecated("Use advertise(rclcpp::node_interfaces, ..., rclcpp::QoS, ...) instead")]]
   POINT_CLOUD_TRANSPORT_PUBLIC
   void advertise(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
@@ -83,6 +84,17 @@ public:
       rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
+    const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions());
+
+  POINT_CLOUD_TRANSPORT_PUBLIC
+  void advertise(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+    const std::string & base_topic,
+    rclcpp::QoS custom_qos,
     const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions());
 
   //! Returns the number of subscribers that are currently connected to this PublisherPlugin
@@ -135,9 +147,11 @@ protected:
         rclcpp::node_interfaces::NodeParametersInterface,
         rclcpp::node_interfaces::NodeTopicsInterface,
         rclcpp::node_interfaces::NodeLoggingInterface>>(*node),
-      base_topic, custom_qos, options);
+      base_topic, rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos),
+        options);
   }
 
+  [[deprecated("Use advertiseImpl(rclcpp::node_interfaces..., rclcpp::QoS, ...) instead")]]
   virtual void advertiseImpl(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
       rclcpp::node_interfaces::NodeBaseInterface,
@@ -146,6 +160,16 @@ protected:
       rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
+    const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions()) = 0;
+
+  virtual void advertiseImpl(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+    const std::string & base_topic,
+    rclcpp::QoS custom_qos,
     const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions()) = 0;
 };
 

--- a/point_cloud_transport/include/point_cloud_transport/publisher_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/publisher_plugin.hpp
@@ -160,7 +160,13 @@ protected:
       rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
-    const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions()) = 0;
+    const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions())
+  {
+    advertiseImpl(
+      node_interfaces, base_topic,
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos),
+      options);
+  }
 
   virtual void advertiseImpl(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<

--- a/point_cloud_transport/include/point_cloud_transport/simple_publisher_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/simple_publisher_plugin.hpp
@@ -227,16 +227,29 @@ protected:
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
     const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions()) override
   {
+    advertiseImpl(node_interfaces, base_topic,
+        rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+  }
+
+  void advertiseImpl(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+    const std::string & base_topic,
+    rclcpp::QoS custom_qos,
+    const rclcpp::PublisherOptions & options = rclcpp::PublisherOptions()) override
+  {
     std::string transport_topic = getTopicToAdvertise(base_topic);
     simple_impl_ = std::make_unique<SimplePublisherPluginImpl>(node_interfaces);
 
     RCLCPP_DEBUG(simple_impl_->logger_, "getTopicToAdvertise: %s", transport_topic.c_str());
-    auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
     auto node_parameters = node_interfaces->get_node_parameters_interface();
     auto node_topics = node_interfaces->get_node_topics_interface();
     // simple_impl_->pub_ = node->create_publisher<M>(transport_topic, qos, options);
     simple_impl_->pub_ = rclcpp::create_publisher<M>(
-      node_parameters, node_topics, transport_topic, qos, options);
+      node_parameters, node_topics, transport_topic, custom_qos, options);
 
     base_topic_ = simple_impl_->pub_->get_topic_name();
 

--- a/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
@@ -223,16 +223,44 @@ protected:
     const Callback & callback,
     rmw_qos_profile_t custom_qos) override
   {
+    subscribeImpl(node_interfaces, base_topic, callback,
+        rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos));
+  }
+
+  void subscribeImpl(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+    const std::string & base_topic,
+    const Callback & callback,
+    rmw_qos_profile_t custom_qos,
+    rclcpp::SubscriptionOptions options) override
+  {
+    subscribeImpl(node_interfaces, base_topic, callback,
+        rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+  }
+
+  void subscribeImpl(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+    const std::string & base_topic,
+    const Callback & callback,
+    rclcpp::QoS custom_qos) override
+  {
     if (!node_interfaces) {
       throw std::runtime_error("node_interfaces is null");
     }
     impl_ = std::make_unique<Impl>(node_interfaces);
-    auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
     auto node_parameters = node_interfaces->get_node_parameters_interface();
     auto node_topics = node_interfaces->get_node_topics_interface();
     impl_->sub_ = rclcpp::create_subscription<M>(
       node_parameters, node_topics,
-      getTopicToSubscribe(base_topic), qos,
+      getTopicToSubscribe(base_topic), custom_qos,
       [this, callback](const typename std::shared_ptr<const M> msg) {
         this->callback(msg, callback);
       });
@@ -247,16 +275,15 @@ protected:
       rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
     const std::string & base_topic,
     const Callback & callback,
-    rmw_qos_profile_t custom_qos,
+    rclcpp::QoS custom_qos,
     rclcpp::SubscriptionOptions options) override
   {
     impl_ = std::make_unique<Impl>(node_interfaces);
-    auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
     auto node_parameters = node_interfaces->get_node_parameters_interface();
     auto node_topics = node_interfaces->get_node_topics_interface();
     impl_->sub_ = rclcpp::create_subscription<M>(
       node_parameters, node_topics,
-      getTopicToSubscribe(base_topic), qos,
+      getTopicToSubscribe(base_topic), custom_qos,
       [this, callback](const typename std::shared_ptr<const M> msg) {
         this->callback(msg, callback);
       },

--- a/point_cloud_transport/include/point_cloud_transport/subscriber.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/subscriber.hpp
@@ -87,10 +87,12 @@ public:
         rclcpp::node_interfaces::NodeParametersInterface,
         rclcpp::node_interfaces::NodeTopicsInterface,
         rclcpp::node_interfaces::NodeLoggingInterface>>(*node),
-      base_topic, callback, loader, transport, custom_qos, options)
+      base_topic, callback, loader, transport,
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options)
   {
   }
 
+  [[deprecated("Use Subscriber(rclcpp::node_interfaces, ..., rclcpp::QoS, ...) instead")]]
   POINT_CLOUD_TRANSPORT_PUBLIC
   Subscriber(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
@@ -103,6 +105,20 @@ public:
     SubLoaderPtr loader,
     const std::string & transport,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
+    rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions());
+
+  POINT_CLOUD_TRANSPORT_PUBLIC
+  Subscriber(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+    const std::string & base_topic,
+    const Callback & callback,
+    SubLoaderPtr loader,
+    const std::string & transport,
+    rclcpp::QoS custom_qos,
     rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions());
 
   ///

--- a/point_cloud_transport/include/point_cloud_transport/subscriber_filter.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/subscriber_filter.hpp
@@ -119,6 +119,7 @@ public:
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
     rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions());
 
+  [[deprecated("Use subscribe(rclcpp::node_interfaces..., rclcpp::QoS, ...) instead")]]
   POINT_CLOUD_TRANSPORT_PUBLIC
   void subscribe(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
@@ -129,6 +130,18 @@ public:
     const std::string & base_topic,
     const std::string & transport,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
+    rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions());
+
+  POINT_CLOUD_TRANSPORT_PUBLIC
+  void subscribe(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+    const std::string & base_topic,
+    const std::string & transport,
+    rclcpp::QoS custom_qos,
     rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions());
 
   //! Force immediate unsubscription of this subscriber from its topic

--- a/point_cloud_transport/include/point_cloud_transport/subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/subscriber_plugin.hpp
@@ -98,7 +98,8 @@ public:
           rclcpp::node_interfaces::NodeParametersInterface,
           rclcpp::node_interfaces::NodeTopicsInterface,
           rclcpp::node_interfaces::NodeLoggingInterface>>(*node);
-    return subscribeImpl(node_interfaces, base_topic, callback, custom_qos, options);
+    return subscribeImpl(node_interfaces, base_topic, callback,
+        rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
   }
 
   void subscribe(
@@ -110,6 +111,22 @@ public:
     const std::string & base_topic,
     const Callback & callback,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
+    rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
+  {
+    return subscribeImpl(
+      node_interfaces, base_topic, callback,
+        rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+  }
+
+  void subscribe(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> & node_interfaces,
+    const std::string & base_topic,
+    const Callback & callback,
+    rclcpp::QoS custom_qos,
     rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
   {
     return subscribeImpl(node_interfaces, base_topic, callback, custom_qos, options);
@@ -135,6 +152,7 @@ public:
       std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &)>(fp),
       custom_qos, options);
   }
+
   void subscribe(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
       rclcpp::node_interfaces::NodeBaseInterface,
@@ -144,6 +162,23 @@ public:
     const std::string & base_topic,
     void (* fp)(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &),
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
+    rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
+  {
+    return subscribe(
+      node_interfaces, base_topic,
+      std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &)>(fp),
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+  }
+
+  void subscribe(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> & node_interfaces,
+    const std::string & base_topic,
+    void (* fp)(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &),
+    rclcpp::QoS custom_qos,
     rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
   {
     return subscribe(
@@ -172,6 +207,7 @@ public:
       node_interfaces, base_topic,
       std::bind(fp, obj, std::placeholders::_1), custom_qos, options);
   }
+
   template<class T>
   void subscribe(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
@@ -186,7 +222,26 @@ public:
   {
     return subscribe(
       node_interfaces, base_topic,
-      std::bind(fp, obj, std::placeholders::_1), custom_qos, options);
+      std::bind(fp, obj, std::placeholders::_1),
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+  }
+
+  template<class T>
+  void subscribe(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> & node_interfaces,
+    const std::string & base_topic,
+    void (T::* fp)(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &), T * obj,
+    rclcpp::QoS custom_qos,
+    rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
+  {
+    return subscribe(
+      node_interfaces, base_topic,
+      std::bind(fp, obj, std::placeholders::_1),
+      custom_qos, options);
   }
 
   //! Get the transport-specific communication topic.
@@ -241,6 +296,7 @@ protected:
         rclcpp::node_interfaces::NodeLoggingInterface>>(*node),
         base_topic, callback, custom_qos);
   }
+
   virtual void subscribeImpl(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
       rclcpp::node_interfaces::NodeBaseInterface,
@@ -250,6 +306,16 @@ protected:
     const std::string & base_topic,
     const Callback & callback,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default) = 0;
+
+  virtual void subscribeImpl(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+    const std::string & base_topic,
+    const Callback & callback,
+    rclcpp::QoS custom_qos) = 0;
 
   [[deprecated("Use subscribeImpl(rclcpp::node_interfaces...) instead")]]
   virtual void subscribeImpl(
@@ -265,8 +331,27 @@ protected:
         rclcpp::node_interfaces::NodeParametersInterface,
         rclcpp::node_interfaces::NodeTopicsInterface,
         rclcpp::node_interfaces::NodeLoggingInterface>>(*node),
+        base_topic, callback,
+        rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+  }
+
+  virtual void subscribeImpl(
+    std::shared_ptr<rclcpp::Node> node,
+    const std::string & base_topic,
+    const Callback & callback,
+    rclcpp::QoS custom_qos,
+    rclcpp::SubscriptionOptions options)
+  {
+    subscribeImpl(
+      std::make_shared<rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeBaseInterface,
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface,
+        rclcpp::node_interfaces::NodeLoggingInterface>>(*node),
         base_topic, callback, custom_qos, options);
   }
+
+  [[deprecated("Use subscribeImpl(rclcpp::node_interfaces..., rclcpp::QoS, ...) instead")]]
   virtual void subscribeImpl(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
       rclcpp::node_interfaces::NodeBaseInterface,
@@ -276,6 +361,17 @@ protected:
     const std::string & base_topic,
     const Callback & callback,
     rmw_qos_profile_t custom_qos,
+    rclcpp::SubscriptionOptions options) = 0;
+
+  virtual void subscribeImpl(
+    std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+      rclcpp::node_interfaces::NodeBaseInterface,
+      rclcpp::node_interfaces::NodeParametersInterface,
+      rclcpp::node_interfaces::NodeTopicsInterface,
+      rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+    const std::string & base_topic,
+    const Callback & callback,
+    rclcpp::QoS custom_qos,
     rclcpp::SubscriptionOptions options) = 0;
 };
 

--- a/point_cloud_transport/include/point_cloud_transport/subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/subscriber_plugin.hpp
@@ -310,7 +310,14 @@ protected:
       rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
     const std::string & base_topic,
     const Callback & callback,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default) = 0;
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+  {
+    subscribeImpl(
+        node_interfaces,
+        base_topic,
+        callback,
+        rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos));
+  }
 
   virtual void subscribeImpl(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<

--- a/point_cloud_transport/include/point_cloud_transport/subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/subscriber_plugin.hpp
@@ -102,6 +102,7 @@ public:
         rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
   }
 
+  [[deprecated("Use subscribe(rclcpp::node_interfaces, ..., rclcpp::QoS, ...) instead")]]
   void subscribe(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
       rclcpp::node_interfaces::NodeBaseInterface,
@@ -150,9 +151,10 @@ public:
     return subscribe(
       node_interfaces, base_topic,
       std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &)>(fp),
-      custom_qos, options);
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
   }
 
+  [[deprecated("Use subscribe(rclcpp::node_interfaces, ..., rclcpp::QoS, ...) instead")]]
   void subscribe(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
       rclcpp::node_interfaces::NodeBaseInterface,
@@ -209,6 +211,7 @@ public:
   }
 
   template<class T>
+  [[deprecated("Use subscribe(rclcpp::node_interfaces, ..., rclcpp::QoS, ...) instead")]]
   void subscribe(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
       rclcpp::node_interfaces::NodeBaseInterface,
@@ -294,9 +297,11 @@ protected:
         rclcpp::node_interfaces::NodeParametersInterface,
         rclcpp::node_interfaces::NodeTopicsInterface,
         rclcpp::node_interfaces::NodeLoggingInterface>>(*node),
-        base_topic, callback, custom_qos);
+        base_topic, callback,
+        rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos));
   }
 
+  [[deprecated("Use subscribeImpl(rclcpp::node_interfaces..., rclcpp::QoS, ...) instead")]]
   virtual void subscribeImpl(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
       rclcpp::node_interfaces::NodeBaseInterface,

--- a/point_cloud_transport/include/point_cloud_transport/subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/subscriber_plugin.hpp
@@ -350,7 +350,14 @@ protected:
     const std::string & base_topic,
     const Callback & callback,
     rmw_qos_profile_t custom_qos,
-    rclcpp::SubscriptionOptions options) = 0;
+    rclcpp::SubscriptionOptions options)
+  {
+    subscribeImpl(
+        node_interfaces,
+        base_topic, callback,
+        rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos),
+        options);
+  }
 
   virtual void subscribeImpl(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<

--- a/point_cloud_transport/include/point_cloud_transport/subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/subscriber_plugin.hpp
@@ -335,22 +335,6 @@ protected:
         rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
   }
 
-  virtual void subscribeImpl(
-    std::shared_ptr<rclcpp::Node> node,
-    const std::string & base_topic,
-    const Callback & callback,
-    rclcpp::QoS custom_qos,
-    rclcpp::SubscriptionOptions options)
-  {
-    subscribeImpl(
-      std::make_shared<rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeBaseInterface,
-        rclcpp::node_interfaces::NodeParametersInterface,
-        rclcpp::node_interfaces::NodeTopicsInterface,
-        rclcpp::node_interfaces::NodeLoggingInterface>>(*node),
-        base_topic, callback, custom_qos, options);
-  }
-
   [[deprecated("Use subscribeImpl(rclcpp::node_interfaces..., rclcpp::QoS, ...) instead")]]
   virtual void subscribeImpl(
     std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<

--- a/point_cloud_transport/src/point_cloud_transport.cpp
+++ b/point_cloud_transport/src/point_cloud_transport.cpp
@@ -138,24 +138,6 @@ Subscriber create_subscription(
 }
 
 Subscriber create_subscription(
-  std::shared_ptr<rclcpp::Node> node,
-  const std::string & base_topic,
-  const Subscriber::Callback & callback,
-  const std::string & transport,
-  rclcpp::QoS custom_qos,
-  rclcpp::SubscriptionOptions options)
-{
-  auto node_interfaces = std::make_shared<rclcpp::node_interfaces::NodeInterfaces<
-        rclcpp::node_interfaces::NodeBaseInterface,
-        rclcpp::node_interfaces::NodeParametersInterface,
-        rclcpp::node_interfaces::NodeTopicsInterface,
-        rclcpp::node_interfaces::NodeLoggingInterface>>(*node);
-  return Subscriber(
-    node_interfaces, base_topic, callback,
-    kImpl->getSubLoader(), transport, custom_qos, options);
-}
-
-Subscriber create_subscription(
   std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
     rclcpp::node_interfaces::NodeBaseInterface,
     rclcpp::node_interfaces::NodeParametersInterface,

--- a/point_cloud_transport/src/point_cloud_transport.cpp
+++ b/point_cloud_transport/src/point_cloud_transport.cpp
@@ -87,8 +87,10 @@ Publisher create_publisher(
         rclcpp::node_interfaces::NodeParametersInterface,
         rclcpp::node_interfaces::NodeTopicsInterface,
         rclcpp::node_interfaces::NodeLoggingInterface>>(*node);
-  return Publisher(node_interfaces, base_topic, kImpl->getPubLoader(), custom_qos, options);
+  return Publisher(node_interfaces, base_topic, kImpl->getPubLoader(),
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
 }
+
 Publisher create_publisher(
   std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
     rclcpp::node_interfaces::NodeBaseInterface,
@@ -97,6 +99,20 @@ Publisher create_publisher(
     rclcpp::node_interfaces::NodeLoggingInterface>> & node_interfaces,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos,
+  const rclcpp::PublisherOptions & options)
+{
+  return Publisher(node_interfaces, base_topic, kImpl->getPubLoader(),
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+}
+
+Publisher create_publisher(
+  std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+    rclcpp::node_interfaces::NodeBaseInterface,
+    rclcpp::node_interfaces::NodeParametersInterface,
+    rclcpp::node_interfaces::NodeTopicsInterface,
+    rclcpp::node_interfaces::NodeLoggingInterface>> & node_interfaces,
+  const std::string & base_topic,
+  rclcpp::QoS custom_qos,
   const rclcpp::PublisherOptions & options)
 {
   return Publisher(node_interfaces, base_topic, kImpl->getPubLoader(), custom_qos, options);
@@ -117,8 +133,28 @@ Subscriber create_subscription(
         rclcpp::node_interfaces::NodeLoggingInterface>>(*node);
   return Subscriber(
     node_interfaces, base_topic, callback,
+    kImpl->getSubLoader(), transport,
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+}
+
+Subscriber create_subscription(
+  std::shared_ptr<rclcpp::Node> node,
+  const std::string & base_topic,
+  const Subscriber::Callback & callback,
+  const std::string & transport,
+  rclcpp::QoS custom_qos,
+  rclcpp::SubscriptionOptions options)
+{
+  auto node_interfaces = std::make_shared<rclcpp::node_interfaces::NodeInterfaces<
+        rclcpp::node_interfaces::NodeBaseInterface,
+        rclcpp::node_interfaces::NodeParametersInterface,
+        rclcpp::node_interfaces::NodeTopicsInterface,
+        rclcpp::node_interfaces::NodeLoggingInterface>>(*node);
+  return Subscriber(
+    node_interfaces, base_topic, callback,
     kImpl->getSubLoader(), transport, custom_qos, options);
 }
+
 Subscriber create_subscription(
   std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
     rclcpp::node_interfaces::NodeBaseInterface,
@@ -129,6 +165,24 @@ Subscriber create_subscription(
   const Subscriber::Callback & callback,
   const std::string & transport,
   rmw_qos_profile_t custom_qos,
+  rclcpp::SubscriptionOptions options)
+{
+  return Subscriber(
+    node_interfaces, base_topic, callback,
+    kImpl->getSubLoader(), transport,
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+}
+
+Subscriber create_subscription(
+  std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+    rclcpp::node_interfaces::NodeBaseInterface,
+    rclcpp::node_interfaces::NodeParametersInterface,
+    rclcpp::node_interfaces::NodeTopicsInterface,
+    rclcpp::node_interfaces::NodeLoggingInterface>> & node_interfaces,
+  const std::string & base_topic,
+  const Subscriber::Callback & callback,
+  const std::string & transport,
+  rclcpp::QoS custom_qos,
   rclcpp::SubscriptionOptions options)
 {
   return Subscriber(

--- a/point_cloud_transport/src/publisher.cpp
+++ b/point_cloud_transport/src/publisher.cpp
@@ -113,7 +113,7 @@ Publisher::Publisher(
     rclcpp::node_interfaces::NodeTopicsInterface,
     rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
   const std::string & base_topic,
-  PubLoaderPtr loader, rmw_qos_profile_t custom_qos,
+  PubLoaderPtr loader, rclcpp::QoS custom_qos,
   const rclcpp::PublisherOptions & options)
 : impl_(std::make_shared<Impl>(node_interfaces))
 {
@@ -176,6 +176,20 @@ Publisher::Publisher(
             "No plugins found! Does `rospack plugins --attrib=plugin "
             "point_cloud_transport` find any packages?");
   }
+}
+
+Publisher::Publisher(
+  std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+    rclcpp::node_interfaces::NodeBaseInterface,
+    rclcpp::node_interfaces::NodeParametersInterface,
+    rclcpp::node_interfaces::NodeTopicsInterface,
+    rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+  const std::string & base_topic,
+  PubLoaderPtr loader, rmw_qos_profile_t custom_qos,
+  const rclcpp::PublisherOptions & options)
+: Publisher(node_interfaces, base_topic, loader,
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options)
+{
 }
 
 uint32_t Publisher::getNumSubscribers() const

--- a/point_cloud_transport/src/publisher_plugin.cpp
+++ b/point_cloud_transport/src/publisher_plugin.cpp
@@ -49,7 +49,8 @@ void PublisherPlugin::advertise(
         rclcpp::node_interfaces::NodeParametersInterface,
         rclcpp::node_interfaces::NodeTopicsInterface,
         rclcpp::node_interfaces::NodeLoggingInterface>>(*node);
-  advertiseImpl(node_interfaces, base_topic, custom_qos, options);
+  advertiseImpl(node_interfaces, base_topic,
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
 }
 
 void PublisherPlugin::advertise(
@@ -60,6 +61,20 @@ void PublisherPlugin::advertise(
     rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos,
+  const rclcpp::PublisherOptions & options)
+{
+  advertiseImpl(node_interfaces, base_topic,
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+}
+
+void PublisherPlugin::advertise(
+  std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+    rclcpp::node_interfaces::NodeBaseInterface,
+    rclcpp::node_interfaces::NodeParametersInterface,
+    rclcpp::node_interfaces::NodeTopicsInterface,
+    rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+  const std::string & base_topic,
+  rclcpp::QoS custom_qos,
   const rclcpp::PublisherOptions & options)
 {
   advertiseImpl(node_interfaces, base_topic, custom_qos, options);

--- a/point_cloud_transport/src/republish.cpp
+++ b/point_cloud_transport/src/republish.cpp
@@ -159,7 +159,7 @@ void Republisher::initialize()
       std::make_shared<point_cloud_transport::Publisher>(
       pct->advertise(
         out_topic,
-        rmw_qos_profile_default,
+        rclcpp::SystemDefaultsQoS(),
         pub_options));
 
     RCLCPP_INFO_STREAM(
@@ -186,7 +186,7 @@ void Republisher::initialize()
     auto instance = loader->createUniqueInstance(lookup_name);
     // DO NOT use instance after this line
     this->pub = std::move(instance);
-    pub->advertise(this->node_interfaces_, out_topic, rmw_qos_profile_default, pub_options);
+    pub->advertise(this->node_interfaces_, out_topic, rclcpp::SystemDefaultsQoS(), pub_options);
 
     RCLCPP_INFO_STREAM(
       this->get_logger(),

--- a/point_cloud_transport/src/subscriber.cpp
+++ b/point_cloud_transport/src/subscriber.cpp
@@ -99,7 +99,7 @@ Subscriber::Subscriber(
   const Callback & callback,
   SubLoaderPtr loader,
   const std::string & transport,
-  rmw_qos_profile_t custom_qos,
+  rclcpp::QoS custom_qos,
   rclcpp::SubscriptionOptions options)
 : impl_(std::make_shared<Impl>(node_interfaces, loader))
 {
@@ -136,6 +136,23 @@ Subscriber::Subscriber(
   // Tell plugin to subscribe.
   impl_->subscriber_->subscribe(node_interfaces, base_topic, callback, custom_qos, options);
   RCLCPP_INFO(impl_->logger_, "Subscribing to: %s\n", impl_->subscriber_->getTopic().c_str());
+}
+
+Subscriber::Subscriber(
+  std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+    rclcpp::node_interfaces::NodeBaseInterface,
+    rclcpp::node_interfaces::NodeParametersInterface,
+    rclcpp::node_interfaces::NodeTopicsInterface,
+    rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+  const std::string & base_topic,
+  const Callback & callback,
+  SubLoaderPtr loader,
+  const std::string & transport,
+  rmw_qos_profile_t custom_qos,
+  rclcpp::SubscriptionOptions options)
+: Subscriber(node_interfaces, base_topic, callback, loader, transport,
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options)
+{
 }
 
 std::string Subscriber::getTopic() const

--- a/point_cloud_transport/src/subscriber_filter.cpp
+++ b/point_cloud_transport/src/subscriber_filter.cpp
@@ -42,7 +42,7 @@ SubscriberFilter::SubscriberFilter(
   const std::string & base_topic,
   const std::string & transport)
 {
-  subscribe(node_interfaces, base_topic, transport);
+  subscribe(node_interfaces, base_topic, transport, rclcpp::SystemDefaultsQoS());
 }
 
 SubscriberFilter::SubscriberFilter()
@@ -82,6 +82,21 @@ void SubscriberFilter::subscribe(
   const std::string & base_topic,
   const std::string & transport,
   rmw_qos_profile_t custom_qos,
+  rclcpp::SubscriptionOptions options)
+{
+  subscribe(node_interfaces, base_topic, transport,
+      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+}
+
+void SubscriberFilter::subscribe(
+  std::shared_ptr<rclcpp::node_interfaces::NodeInterfaces<
+    rclcpp::node_interfaces::NodeBaseInterface,
+    rclcpp::node_interfaces::NodeParametersInterface,
+    rclcpp::node_interfaces::NodeTopicsInterface,
+    rclcpp::node_interfaces::NodeLoggingInterface>> node_interfaces,
+  const std::string & base_topic,
+  const std::string & transport,
+  rclcpp::QoS custom_qos,
   rclcpp::SubscriptionOptions options)
 {
   unsubscribe();

--- a/point_cloud_transport/src/subscriber_filter.cpp
+++ b/point_cloud_transport/src/subscriber_filter.cpp
@@ -70,7 +70,9 @@ void SubscriberFilter::subscribe(
   sub_ = point_cloud_transport::create_subscription(
     node_interfaces, base_topic,
     std::bind(&SubscriberFilter::cb, this, std::placeholders::_1),
-    transport, custom_qos, options);
+    transport,
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos),
+    options);
 }
 
 void SubscriberFilter::subscribe(
@@ -85,7 +87,7 @@ void SubscriberFilter::subscribe(
   rclcpp::SubscriptionOptions options)
 {
   subscribe(node_interfaces, base_topic, transport,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
 }
 
 void SubscriberFilter::subscribe(

--- a/point_cloud_transport/test/test_message_passing.cpp
+++ b/point_cloud_transport/test/test_message_passing.cpp
@@ -148,11 +148,14 @@ TEST_F(MessagePassingTesting, one_message_passing_ni_api)
 
   rclcpp::executors::SingleThreadedExecutor executor;
 
-  auto pub = point_cloud_transport::create_publisher(node_interfaces_, "pointcloud");
+  auto pub = point_cloud_transport::create_publisher(
+    node_interfaces_,
+    "pointcloud",
+    rclcpp::SystemDefaultsQoS());
   auto sub =
     point_cloud_transport::create_subscription(
     node_interfaces_, "pointcloud", pointcloudCallback,
-    "raw");
+    "raw", rclcpp::SystemDefaultsQoS());
 
   test_rclcpp::wait_for_subscriber(node_, sub.getTopic());
 

--- a/point_cloud_transport/test/test_publisher.cpp
+++ b/point_cloud_transport/test/test_publisher.cpp
@@ -97,7 +97,10 @@ TEST_F(TestPublisher, point_cloud_transport_publisher)
 
 TEST_F(TestPublisher, publisher_ni_api)
 {
-  auto pub = point_cloud_transport::create_publisher(node_interfaces_, "point_cloud");
+  auto pub = point_cloud_transport::create_publisher(
+    node_interfaces_,
+    "point_cloud",
+    rclcpp::SystemDefaultsQoS());
   EXPECT_EQ(node_->get_node_graph_interface()->count_publishers("point_cloud"), 1u);
   pub.shutdown();
   EXPECT_EQ(node_->get_node_graph_interface()->count_publishers("point_cloud"), 0u);

--- a/point_cloud_transport/test/test_publisher.cpp
+++ b/point_cloud_transport/test/test_publisher.cpp
@@ -109,7 +109,7 @@ TEST_F(TestPublisher, publisher_ni_api)
 TEST_F(TestPublisher, point_cloud_transport_publisher_ni_api)
 {
   point_cloud_transport::PointCloudTransport it(node_interfaces_);
-  auto pub = it.advertise("point_cloud", rmw_qos_profile_sensor_data);
+  auto pub = it.advertise("point_cloud", rclcpp::SystemDefaultsQoS());
 }
 
 int main(int argc, char ** argv)

--- a/point_cloud_transport/test/test_qos_override.cpp
+++ b/point_cloud_transport/test/test_qos_override.cpp
@@ -95,108 +95,108 @@ protected:
   NodeInterfacesPtr qos_override_sub_node_ni_;
 };
 
-// #ifdef _MSC_VER
-// #pragma warning(push)
-// #pragma warning(disable : 4996)
-// #else
-// #pragma GCC diagnostic push
-// #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-// #endif
-// TEST_F(TestQosOverride, qos_override_publisher_without_options) {
-//   auto pub = point_cloud_transport::create_publisher(
-//     pub_node_, "pointcloud",
-//     rmw_qos_profile_default);
-//   auto endpoint_info_vec = pub_node_->get_publishers_info_by_topic("pointcloud");
-//   EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
-//   pub.shutdown();
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+TEST_F(TestQosOverride, qos_override_publisher_without_options) {
+  auto pub = point_cloud_transport::create_publisher(
+    pub_node_, "pointcloud",
+    rmw_qos_profile_default);
+  auto endpoint_info_vec = pub_node_->get_publishers_info_by_topic("pointcloud");
+  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
+  pub.shutdown();
 
-//   pub = point_cloud_transport::create_publisher(
-//     qos_override_pub_node_, "pointcloud", rmw_qos_profile_default);
+  pub = point_cloud_transport::create_publisher(
+    qos_override_pub_node_, "pointcloud", rmw_qos_profile_default);
 
-//   endpoint_info_vec = qos_override_pub_node_->get_publishers_info_by_topic("pointcloud");
-//   EXPECT_EQ(
-//     endpoint_info_vec[0].qos_profile().reliability(),
-//     rclcpp::ReliabilityPolicy::Reliable);
-//   pub.shutdown();
-// }
+  endpoint_info_vec = qos_override_pub_node_->get_publishers_info_by_topic("pointcloud");
+  EXPECT_EQ(
+    endpoint_info_vec[0].qos_profile().reliability(),
+    rclcpp::ReliabilityPolicy::Reliable);
+  pub.shutdown();
+}
 
-// TEST_F(TestQosOverride, qos_override_publisher_with_options) {
-//   rclcpp::PublisherOptions options;
-//   options.qos_overriding_options = rclcpp::QosOverridingOptions(
-//   {
-//     rclcpp::QosPolicyKind::Depth,
-//     rclcpp::QosPolicyKind::Durability,
-//     rclcpp::QosPolicyKind::History,
-//     rclcpp::QosPolicyKind::Reliability,
-//   });
+TEST_F(TestQosOverride, qos_override_publisher_with_options) {
+  rclcpp::PublisherOptions options;
+  options.qos_overriding_options = rclcpp::QosOverridingOptions(
+  {
+    rclcpp::QosPolicyKind::Depth,
+    rclcpp::QosPolicyKind::Durability,
+    rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Reliability,
+  });
 
-//   auto pub = point_cloud_transport::create_publisher(
-//     pub_node_, "pointcloud", rmw_qos_profile_default, options);
-//   auto endpoint_info_vec = pub_node_->get_publishers_info_by_topic("pointcloud");
-//   EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
-//   pub.shutdown();
+  auto pub = point_cloud_transport::create_publisher(
+    pub_node_, "pointcloud", rmw_qos_profile_default, options);
+  auto endpoint_info_vec = pub_node_->get_publishers_info_by_topic("pointcloud");
+  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
+  pub.shutdown();
 
-//   pub = point_cloud_transport::create_publisher(
-//     qos_override_pub_node_, "pointcloud", rmw_qos_profile_default, options);
+  pub = point_cloud_transport::create_publisher(
+    qos_override_pub_node_, "pointcloud", rmw_qos_profile_default, options);
 
-//   endpoint_info_vec = qos_override_pub_node_->get_publishers_info_by_topic("pointcloud");
-//   EXPECT_EQ(
-//     endpoint_info_vec[0].qos_profile().reliability(),
-//     rclcpp::ReliabilityPolicy::BestEffort);
-//   pub.shutdown();
-// }
+  endpoint_info_vec = qos_override_pub_node_->get_publishers_info_by_topic("pointcloud");
+  EXPECT_EQ(
+    endpoint_info_vec[0].qos_profile().reliability(),
+    rclcpp::ReliabilityPolicy::BestEffort);
+  pub.shutdown();
+}
 
-// TEST_F(TestQosOverride, qos_override_subscriber_without_options) {
-//   std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)> fcn =
-//     [](const auto & msg) {(void)msg;};
+TEST_F(TestQosOverride, qos_override_subscriber_without_options) {
+  std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)> fcn =
+    [](const auto & msg) {(void)msg;};
 
-//   auto sub = point_cloud_transport::create_subscription(
-//     sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default);
-//   auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
-//   EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
-//   sub.shutdown();
+  auto sub = point_cloud_transport::create_subscription(
+    sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default);
+  auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
+  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
+  sub.shutdown();
 
-//   sub = point_cloud_transport::create_subscription(
-//     qos_override_sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default);
+  sub = point_cloud_transport::create_subscription(
+    qos_override_sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default);
 
-//   endpoint_info_vec = qos_override_sub_node_->get_subscriptions_info_by_topic("pointcloud");
-//   EXPECT_EQ(
-//     endpoint_info_vec[0].qos_profile().reliability(),
-//     rclcpp::ReliabilityPolicy::Reliable);
-// }
+  endpoint_info_vec = qos_override_sub_node_->get_subscriptions_info_by_topic("pointcloud");
+  EXPECT_EQ(
+    endpoint_info_vec[0].qos_profile().reliability(),
+    rclcpp::ReliabilityPolicy::Reliable);
+}
 
-// TEST_F(TestQosOverride, qos_override_subscriber_with_options) {
-//   std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)> fcn =
-//     [](const auto & msg) {(void)msg;};
+TEST_F(TestQosOverride, qos_override_subscriber_with_options) {
+  std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)> fcn =
+    [](const auto & msg) {(void)msg;};
 
-//   rclcpp::SubscriptionOptions options;
-//   options.qos_overriding_options = rclcpp::QosOverridingOptions(
-//   {
-//     rclcpp::QosPolicyKind::Depth,
-//     rclcpp::QosPolicyKind::Durability,
-//     rclcpp::QosPolicyKind::History,
-//     rclcpp::QosPolicyKind::Reliability,
-//   });
+  rclcpp::SubscriptionOptions options;
+  options.qos_overriding_options = rclcpp::QosOverridingOptions(
+  {
+    rclcpp::QosPolicyKind::Depth,
+    rclcpp::QosPolicyKind::Durability,
+    rclcpp::QosPolicyKind::History,
+    rclcpp::QosPolicyKind::Reliability,
+  });
 
-//   auto sub = point_cloud_transport::create_subscription(
-//     sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default, options);
-//   auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
-//   EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
-//   sub.shutdown();
+  auto sub = point_cloud_transport::create_subscription(
+    sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default, options);
+  auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
+  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
+  sub.shutdown();
 
-//   sub = point_cloud_transport::create_subscription(
-//     qos_override_sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default, options);
+  sub = point_cloud_transport::create_subscription(
+    qos_override_sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default, options);
 
-//   endpoint_info_vec = qos_override_sub_node_->get_subscriptions_info_by_topic("pointcloud");
-//   EXPECT_EQ(
-//     endpoint_info_vec[0].qos_profile().reliability(),
-//     rclcpp::ReliabilityPolicy::BestEffort);
-// }
-// #ifdef _MSC_VER
-// #pragma warning(pop)
-// #else
-// #pragma GCC diagnostic pop
-// #endif
+  endpoint_info_vec = qos_override_sub_node_->get_subscriptions_info_by_topic("pointcloud");
+  EXPECT_EQ(
+    endpoint_info_vec[0].qos_profile().reliability(),
+    rclcpp::ReliabilityPolicy::BestEffort);
+}
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif
 
 TEST_F(TestQosOverride, qos_override_publisher_without_options_ni_api) {
   auto pub = point_cloud_transport::create_publisher(
@@ -249,7 +249,7 @@ TEST_F(TestQosOverride, qos_override_subscriber_without_options_ni_api) {
   auto sub = point_cloud_transport::create_subscription(
     sub_node_ni_, "pointcloud", fcn, "raw", rclcpp::SystemDefaultsQoS());
   auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
-  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
+  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::BestEffort);
   sub.shutdown();
 
   sub = point_cloud_transport::create_subscription(
@@ -258,7 +258,7 @@ TEST_F(TestQosOverride, qos_override_subscriber_without_options_ni_api) {
   endpoint_info_vec = qos_override_sub_node_->get_subscriptions_info_by_topic("pointcloud");
   EXPECT_EQ(
     endpoint_info_vec[0].qos_profile().reliability(),
-    rclcpp::ReliabilityPolicy::Reliable);
+    rclcpp::ReliabilityPolicy::BestEffort);
 }
 
 TEST_F(TestQosOverride, qos_override_subscriber_with_options_ni_api) {
@@ -277,7 +277,7 @@ TEST_F(TestQosOverride, qos_override_subscriber_with_options_ni_api) {
   auto sub = point_cloud_transport::create_subscription(
     sub_node_ni_, "pointcloud", fcn, "raw", rclcpp::SystemDefaultsQoS(), options);
   auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
-  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
+  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::BestEffort);
   sub.shutdown();
 
   sub = point_cloud_transport::create_subscription(

--- a/point_cloud_transport/test/test_qos_override.cpp
+++ b/point_cloud_transport/test/test_qos_override.cpp
@@ -249,7 +249,8 @@ TEST_F(TestQosOverride, qos_override_subscriber_without_options_ni_api) {
   auto sub = point_cloud_transport::create_subscription(
     sub_node_ni_, "pointcloud", fcn, "raw", rclcpp::SystemDefaultsQoS());
   auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
-  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::BestEffort);
+  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(),
+    rclcpp::ReliabilityPolicy::BestEffort);
   sub.shutdown();
 
   sub = point_cloud_transport::create_subscription(
@@ -277,7 +278,8 @@ TEST_F(TestQosOverride, qos_override_subscriber_with_options_ni_api) {
   auto sub = point_cloud_transport::create_subscription(
     sub_node_ni_, "pointcloud", fcn, "raw", rclcpp::SystemDefaultsQoS(), options);
   auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
-  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::BestEffort);
+  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(),
+    rclcpp::ReliabilityPolicy::BestEffort);
   sub.shutdown();
 
   sub = point_cloud_transport::create_subscription(

--- a/point_cloud_transport/test/test_qos_override.cpp
+++ b/point_cloud_transport/test/test_qos_override.cpp
@@ -95,119 +95,119 @@ protected:
   NodeInterfacesPtr qos_override_sub_node_ni_;
 };
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-TEST_F(TestQosOverride, qos_override_publisher_without_options) {
-  auto pub = point_cloud_transport::create_publisher(
-    pub_node_, "pointcloud",
-    rmw_qos_profile_default);
-  auto endpoint_info_vec = pub_node_->get_publishers_info_by_topic("pointcloud");
-  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
-  pub.shutdown();
+// #ifdef _MSC_VER
+// #pragma warning(push)
+// #pragma warning(disable : 4996)
+// #else
+// #pragma GCC diagnostic push
+// #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// #endif
+// TEST_F(TestQosOverride, qos_override_publisher_without_options) {
+//   auto pub = point_cloud_transport::create_publisher(
+//     pub_node_, "pointcloud",
+//     rmw_qos_profile_default);
+//   auto endpoint_info_vec = pub_node_->get_publishers_info_by_topic("pointcloud");
+//   EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
+//   pub.shutdown();
 
-  pub = point_cloud_transport::create_publisher(
-    qos_override_pub_node_, "pointcloud", rmw_qos_profile_default);
+//   pub = point_cloud_transport::create_publisher(
+//     qos_override_pub_node_, "pointcloud", rmw_qos_profile_default);
 
-  endpoint_info_vec = qos_override_pub_node_->get_publishers_info_by_topic("pointcloud");
-  EXPECT_EQ(
-    endpoint_info_vec[0].qos_profile().reliability(),
-    rclcpp::ReliabilityPolicy::Reliable);
-  pub.shutdown();
-}
+//   endpoint_info_vec = qos_override_pub_node_->get_publishers_info_by_topic("pointcloud");
+//   EXPECT_EQ(
+//     endpoint_info_vec[0].qos_profile().reliability(),
+//     rclcpp::ReliabilityPolicy::Reliable);
+//   pub.shutdown();
+// }
 
-TEST_F(TestQosOverride, qos_override_publisher_with_options) {
-  rclcpp::PublisherOptions options;
-  options.qos_overriding_options = rclcpp::QosOverridingOptions(
-  {
-    rclcpp::QosPolicyKind::Depth,
-    rclcpp::QosPolicyKind::Durability,
-    rclcpp::QosPolicyKind::History,
-    rclcpp::QosPolicyKind::Reliability,
-  });
+// TEST_F(TestQosOverride, qos_override_publisher_with_options) {
+//   rclcpp::PublisherOptions options;
+//   options.qos_overriding_options = rclcpp::QosOverridingOptions(
+//   {
+//     rclcpp::QosPolicyKind::Depth,
+//     rclcpp::QosPolicyKind::Durability,
+//     rclcpp::QosPolicyKind::History,
+//     rclcpp::QosPolicyKind::Reliability,
+//   });
 
-  auto pub = point_cloud_transport::create_publisher(
-    pub_node_, "pointcloud", rmw_qos_profile_default, options);
-  auto endpoint_info_vec = pub_node_->get_publishers_info_by_topic("pointcloud");
-  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
-  pub.shutdown();
+//   auto pub = point_cloud_transport::create_publisher(
+//     pub_node_, "pointcloud", rmw_qos_profile_default, options);
+//   auto endpoint_info_vec = pub_node_->get_publishers_info_by_topic("pointcloud");
+//   EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
+//   pub.shutdown();
 
-  pub = point_cloud_transport::create_publisher(
-    qos_override_pub_node_, "pointcloud", rmw_qos_profile_default, options);
+//   pub = point_cloud_transport::create_publisher(
+//     qos_override_pub_node_, "pointcloud", rmw_qos_profile_default, options);
 
-  endpoint_info_vec = qos_override_pub_node_->get_publishers_info_by_topic("pointcloud");
-  EXPECT_EQ(
-    endpoint_info_vec[0].qos_profile().reliability(),
-    rclcpp::ReliabilityPolicy::BestEffort);
-  pub.shutdown();
-}
+//   endpoint_info_vec = qos_override_pub_node_->get_publishers_info_by_topic("pointcloud");
+//   EXPECT_EQ(
+//     endpoint_info_vec[0].qos_profile().reliability(),
+//     rclcpp::ReliabilityPolicy::BestEffort);
+//   pub.shutdown();
+// }
 
-TEST_F(TestQosOverride, qos_override_subscriber_without_options) {
-  std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)> fcn =
-    [](const auto & msg) {(void)msg;};
+// TEST_F(TestQosOverride, qos_override_subscriber_without_options) {
+//   std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)> fcn =
+//     [](const auto & msg) {(void)msg;};
 
-  auto sub = point_cloud_transport::create_subscription(
-    sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default);
-  auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
-  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
-  sub.shutdown();
+//   auto sub = point_cloud_transport::create_subscription(
+//     sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default);
+//   auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
+//   EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
+//   sub.shutdown();
 
-  sub = point_cloud_transport::create_subscription(
-    qos_override_sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default);
+//   sub = point_cloud_transport::create_subscription(
+//     qos_override_sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default);
 
-  endpoint_info_vec = qos_override_sub_node_->get_subscriptions_info_by_topic("pointcloud");
-  EXPECT_EQ(
-    endpoint_info_vec[0].qos_profile().reliability(),
-    rclcpp::ReliabilityPolicy::Reliable);
-}
+//   endpoint_info_vec = qos_override_sub_node_->get_subscriptions_info_by_topic("pointcloud");
+//   EXPECT_EQ(
+//     endpoint_info_vec[0].qos_profile().reliability(),
+//     rclcpp::ReliabilityPolicy::Reliable);
+// }
 
-TEST_F(TestQosOverride, qos_override_subscriber_with_options) {
-  std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)> fcn =
-    [](const auto & msg) {(void)msg;};
+// TEST_F(TestQosOverride, qos_override_subscriber_with_options) {
+//   std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)> fcn =
+//     [](const auto & msg) {(void)msg;};
 
-  rclcpp::SubscriptionOptions options;
-  options.qos_overriding_options = rclcpp::QosOverridingOptions(
-  {
-    rclcpp::QosPolicyKind::Depth,
-    rclcpp::QosPolicyKind::Durability,
-    rclcpp::QosPolicyKind::History,
-    rclcpp::QosPolicyKind::Reliability,
-  });
+//   rclcpp::SubscriptionOptions options;
+//   options.qos_overriding_options = rclcpp::QosOverridingOptions(
+//   {
+//     rclcpp::QosPolicyKind::Depth,
+//     rclcpp::QosPolicyKind::Durability,
+//     rclcpp::QosPolicyKind::History,
+//     rclcpp::QosPolicyKind::Reliability,
+//   });
 
-  auto sub = point_cloud_transport::create_subscription(
-    sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default, options);
-  auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
-  EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
-  sub.shutdown();
+//   auto sub = point_cloud_transport::create_subscription(
+//     sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default, options);
+//   auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
+//   EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
+//   sub.shutdown();
 
-  sub = point_cloud_transport::create_subscription(
-    qos_override_sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default, options);
+//   sub = point_cloud_transport::create_subscription(
+//     qos_override_sub_node_, "pointcloud", fcn, "raw", rmw_qos_profile_default, options);
 
-  endpoint_info_vec = qos_override_sub_node_->get_subscriptions_info_by_topic("pointcloud");
-  EXPECT_EQ(
-    endpoint_info_vec[0].qos_profile().reliability(),
-    rclcpp::ReliabilityPolicy::BestEffort);
-}
-#ifdef _MSC_VER
-#pragma warning(pop)
-#else
-#pragma GCC diagnostic pop
-#endif
+//   endpoint_info_vec = qos_override_sub_node_->get_subscriptions_info_by_topic("pointcloud");
+//   EXPECT_EQ(
+//     endpoint_info_vec[0].qos_profile().reliability(),
+//     rclcpp::ReliabilityPolicy::BestEffort);
+// }
+// #ifdef _MSC_VER
+// #pragma warning(pop)
+// #else
+// #pragma GCC diagnostic pop
+// #endif
 
 TEST_F(TestQosOverride, qos_override_publisher_without_options_ni_api) {
   auto pub = point_cloud_transport::create_publisher(
     pub_node_ni_, "pointcloud",
-    rmw_qos_profile_default);
+    rclcpp::SystemDefaultsQoS());
   auto endpoint_info_vec = pub_node_->get_publishers_info_by_topic("pointcloud");
   EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
   pub.shutdown();
 
   pub = point_cloud_transport::create_publisher(
-    qos_override_pub_node_ni_, "pointcloud", rmw_qos_profile_default);
+    qos_override_pub_node_ni_, "pointcloud", rclcpp::SystemDefaultsQoS());
 
   endpoint_info_vec = qos_override_pub_node_->get_publishers_info_by_topic("pointcloud");
   EXPECT_EQ(
@@ -227,13 +227,13 @@ TEST_F(TestQosOverride, qos_override_publisher_with_options_ni_api) {
   });
 
   auto pub = point_cloud_transport::create_publisher(
-    pub_node_ni_, "pointcloud", rmw_qos_profile_default, options);
+    pub_node_ni_, "pointcloud", rclcpp::SystemDefaultsQoS(), options);
   auto endpoint_info_vec = pub_node_->get_publishers_info_by_topic("pointcloud");
   EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
   pub.shutdown();
 
   pub = point_cloud_transport::create_publisher(
-    qos_override_pub_node_ni_, "pointcloud", rmw_qos_profile_default, options);
+    qos_override_pub_node_ni_, "pointcloud", rclcpp::SystemDefaultsQoS(), options);
 
   endpoint_info_vec = qos_override_pub_node_->get_publishers_info_by_topic("pointcloud");
   EXPECT_EQ(
@@ -247,13 +247,13 @@ TEST_F(TestQosOverride, qos_override_subscriber_without_options_ni_api) {
     [](const auto & msg) {(void)msg;};
 
   auto sub = point_cloud_transport::create_subscription(
-    sub_node_ni_, "pointcloud", fcn, "raw", rmw_qos_profile_default);
+    sub_node_ni_, "pointcloud", fcn, "raw", rclcpp::SystemDefaultsQoS());
   auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
   EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
   sub.shutdown();
 
   sub = point_cloud_transport::create_subscription(
-    qos_override_sub_node_ni_, "pointcloud", fcn, "raw", rmw_qos_profile_default);
+    qos_override_sub_node_ni_, "pointcloud", fcn, "raw", rclcpp::SystemDefaultsQoS());
 
   endpoint_info_vec = qos_override_sub_node_->get_subscriptions_info_by_topic("pointcloud");
   EXPECT_EQ(
@@ -275,13 +275,13 @@ TEST_F(TestQosOverride, qos_override_subscriber_with_options_ni_api) {
   });
 
   auto sub = point_cloud_transport::create_subscription(
-    sub_node_ni_, "pointcloud", fcn, "raw", rmw_qos_profile_default, options);
+    sub_node_ni_, "pointcloud", fcn, "raw", rclcpp::SystemDefaultsQoS(), options);
   auto endpoint_info_vec = sub_node_->get_subscriptions_info_by_topic("pointcloud");
   EXPECT_EQ(endpoint_info_vec[0].qos_profile().reliability(), rclcpp::ReliabilityPolicy::Reliable);
   sub.shutdown();
 
   sub = point_cloud_transport::create_subscription(
-    qos_override_sub_node_ni_, "pointcloud", fcn, "raw", rmw_qos_profile_default, options);
+    qos_override_sub_node_ni_, "pointcloud", fcn, "raw", rclcpp::SystemDefaultsQoS(), options);
 
   endpoint_info_vec = qos_override_sub_node_->get_subscriptions_info_by_topic("pointcloud");
   EXPECT_EQ(

--- a/point_cloud_transport/test/test_remapping.cpp
+++ b/point_cloud_transport/test/test_remapping.cpp
@@ -176,7 +176,8 @@ TEST_F(TestPublisher, RemappedPublisher_ni_api) {
       node_->get_node_topics_interface(),
       node_->get_node_logging_interface()
     );
-  auto pub = point_cloud_transport::create_publisher(node_node_interfaces, "new_topic", rclcpp::SystemDefaultsQoS());
+  auto pub = point_cloud_transport::create_publisher(node_node_interfaces, "new_topic",
+    rclcpp::SystemDefaultsQoS());
 
   ASSERT_EQ("/namespace/new_topic", sub.getTopic());
   ASSERT_EQ("/namespace/new_topic", pub.getTopic());

--- a/point_cloud_transport/test/test_remapping.cpp
+++ b/point_cloud_transport/test/test_remapping.cpp
@@ -160,7 +160,7 @@ TEST_F(TestPublisher, RemappedPublisher_ni_api) {
     [&received](const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg) {
       (void)msg;
       received = true;
-    }, "raw");
+    }, "raw", rclcpp::SystemDefaultsQoS());
 
   // Publish
   auto node_node_interfaces = std::make_shared<
@@ -176,7 +176,7 @@ TEST_F(TestPublisher, RemappedPublisher_ni_api) {
       node_->get_node_topics_interface(),
       node_->get_node_logging_interface()
     );
-  auto pub = point_cloud_transport::create_publisher(node_node_interfaces, "new_topic");
+  auto pub = point_cloud_transport::create_publisher(node_node_interfaces, "new_topic", rclcpp::SystemDefaultsQoS());
 
   ASSERT_EQ("/namespace/new_topic", sub.getTopic());
   ASSERT_EQ("/namespace/new_topic", pub.getTopic());

--- a/point_cloud_transport/test/test_subscriber.cpp
+++ b/point_cloud_transport/test/test_subscriber.cpp
@@ -110,7 +110,8 @@ TEST_F(TestSubscriber, construction_and_destruction_ni_api)
       (void)msg;
     };
 
-  auto sub = point_cloud_transport::create_subscription(node_interfaces_, "pointcloud", fcn, "raw", rclcpp::SystemDefaultsQoS());
+  auto sub = point_cloud_transport::create_subscription(node_interfaces_, "pointcloud", fcn, "raw",
+    rclcpp::SystemDefaultsQoS());
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.spin_node_some(node_);
@@ -121,7 +122,8 @@ TEST_F(TestSubscriber, shutdown_ni_api)
   std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)> fcn =
     [](const auto & msg) {(void)msg;};
 
-  auto sub = point_cloud_transport::create_subscription(node_interfaces_, "pointcloud", fcn, "raw", rclcpp::SystemDefaultsQoS());
+  auto sub = point_cloud_transport::create_subscription(node_interfaces_, "pointcloud", fcn, "raw",
+    rclcpp::SystemDefaultsQoS());
   EXPECT_EQ(node_->get_node_graph_interface()->count_subscribers("pointcloud"), 1u);
   sub.shutdown();
   EXPECT_EQ(node_->get_node_graph_interface()->count_subscribers("pointcloud"), 0u);

--- a/point_cloud_transport/test/test_subscriber.cpp
+++ b/point_cloud_transport/test/test_subscriber.cpp
@@ -110,7 +110,7 @@ TEST_F(TestSubscriber, construction_and_destruction_ni_api)
       (void)msg;
     };
 
-  auto sub = point_cloud_transport::create_subscription(node_interfaces_, "pointcloud", fcn, "raw");
+  auto sub = point_cloud_transport::create_subscription(node_interfaces_, "pointcloud", fcn, "raw", rclcpp::SystemDefaultsQoS());
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.spin_node_some(node_);
@@ -121,7 +121,7 @@ TEST_F(TestSubscriber, shutdown_ni_api)
   std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg)> fcn =
     [](const auto & msg) {(void)msg;};
 
-  auto sub = point_cloud_transport::create_subscription(node_interfaces_, "pointcloud", fcn, "raw");
+  auto sub = point_cloud_transport::create_subscription(node_interfaces_, "pointcloud", fcn, "raw", rclcpp::SystemDefaultsQoS());
   EXPECT_EQ(node_->get_node_graph_interface()->count_subscribers("pointcloud"), 1u);
   sub.shutdown();
   EXPECT_EQ(node_->get_node_graph_interface()->count_subscribers("pointcloud"), 0u);


### PR DESCRIPTION
Deprecated `rmw_qos_profile_t`

I noticed in this issue https://github.com/ros-perception/point_cloud_transport/issues/124 that point_cloud_Transport is still using `rmw_qos_profile_t`. We should use `rclcpp::QoS`.

FYI @elsayedelsheikh