### PR TITLE
Use standard unsigned int in place of uint for Windows compatibility

### DIFF
--- a/point_cloud_transport/include/point_cloud_transport/simple_publisher_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/simple_publisher_plugin.hpp
@@ -95,7 +95,7 @@ public:
   bool getParam(const std::string & parameter_name, T & value) const
   {
     if (simple_impl_) {
-      uint ns_len = strlen(simple_impl_->node_interfaces_
+      unsigned int ns_len = strlen(simple_impl_->node_interfaces_
           .get_node_base_interface()->get_namespace());
       std::string param_base_name = getTopic().substr(ns_len);
       std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
@@ -120,7 +120,7 @@ public:
   {
     if (simple_impl_) {
       // Declare Parameters
-      uint ns_len = strlen(simple_impl_->node_interfaces_
+      unsigned int ns_len = strlen(simple_impl_->node_interfaces_
           .get_node_base_interface()->get_namespace());
       std::string param_base_name = getTopic().substr(ns_len);
       std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');

--- a/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
@@ -93,7 +93,8 @@ public:
   bool getParam(const std::string & parameter_name, T & value) const
   {
     if (impl_) {
-      unsigned int ns_len = strlen(impl_->node_interfaces_.get_node_base_interface()->get_namespace());
+      unsigned int ns_len =
+        strlen(impl_->node_interfaces_.get_node_base_interface()->get_namespace());
       std::string param_base_name = getTopic().substr(ns_len);
       std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
@@ -117,7 +118,8 @@ public:
     rcl_interfaces::msg::ParameterDescriptor())
   {
     if (impl_) {
-      unsigned int ns_len = strlen(impl_->node_interfaces_.get_node_base_interface()->get_namespace());
+      unsigned int ns_len =
+        strlen(impl_->node_interfaces_.get_node_base_interface()->get_namespace());
       std::string param_base_name = getTopic().substr(ns_len);
       std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 

--- a/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
@@ -93,7 +93,7 @@ public:
   bool getParam(const std::string & parameter_name, T & value) const
   {
     if (impl_) {
-      uint ns_len = strlen(impl_->node_interfaces_.get_node_base_interface()->get_namespace());
+      unsigned int ns_len = strlen(impl_->node_interfaces_.get_node_base_interface()->get_namespace());
       std::string param_base_name = getTopic().substr(ns_len);
       std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
@@ -117,7 +117,7 @@ public:
     rcl_interfaces::msg::ParameterDescriptor())
   {
     if (impl_) {
-      uint ns_len = strlen(impl_->node_interfaces_.get_node_base_interface()->get_namespace());
+      unsigned int ns_len = strlen(impl_->node_interfaces_.get_node_base_interface()->get_namespace());
       std::string param_base_name = getTopic().substr(ns_len);
       std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 


### PR DESCRIPTION
See failure in https://github.com/RoboStack/ros-jazzy/pull/111 .