### PR TITLE
Expose original ROS Publishers and Subscription

### DIFF
--- a/point_cloud_transport/include/point_cloud_transport/publisher.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/publisher.hpp
@@ -34,6 +34,7 @@
 
 #include <memory>
 #include <string>
+#include <map>
 
 #include "rclcpp/macros.hpp"
 #include "rclcpp/node.hpp"
@@ -83,9 +84,9 @@ public:
   POINT_CLOUD_TRANSPORT_PUBLIC
   void shutdown();
 
-  //! Get the underlying ROS publisher handles.
+  //! Get the underlying ROS publisher handles mapped by transport name.
   POINT_CLOUD_TRANSPORT_PUBLIC
-  std::vector<rclcpp::PublisherBase::SharedPtr> getPublishers() const;
+  std::map<std::string, rclcpp::PublisherBase::SharedPtr> getPublishers() const;
 
   POINT_CLOUD_TRANSPORT_PUBLIC
   operator void *() const;

--- a/point_cloud_transport/include/point_cloud_transport/publisher.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/publisher.hpp
@@ -83,6 +83,10 @@ public:
   POINT_CLOUD_TRANSPORT_PUBLIC
   void shutdown();
 
+  //! Get the underlying ROS publisher handles.
+  POINT_CLOUD_TRANSPORT_PUBLIC
+  std::vector<rclcpp::PublisherBase::SharedPtr> getPublishers() const;
+
   POINT_CLOUD_TRANSPORT_PUBLIC
   operator void *() const;
 

--- a/point_cloud_transport/include/point_cloud_transport/publisher_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/publisher_plugin.hpp
@@ -96,6 +96,9 @@ public:
   POINT_CLOUD_TRANSPORT_PUBLIC
   virtual void publishPtr(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & message) const;
 
+  //! Get the underlying ROS publisher handle, if available.
+  virtual rclcpp::PublisherBase::SharedPtr getPublisher() const = 0;
+
   //! Shutdown any advertisements associated with this PublisherPlugin.
   virtual void shutdown() = 0;
 

--- a/point_cloud_transport/include/point_cloud_transport/simple_publisher_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/simple_publisher_plugin.hpp
@@ -172,6 +172,14 @@ public:
     simple_impl_.reset();
   }
 
+  rclcpp::PublisherBase::SharedPtr getPublisher() const override
+  {
+    if (simple_impl_) {
+      return simple_impl_->pub_;
+    }
+    return nullptr;
+  }
+
   ///
   /// \brief Encode the given raw pointcloud into a compressed message.
   /// \param[in] raw The input raw pointcloud.

--- a/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/simple_subscriber_plugin.hpp
@@ -155,6 +155,14 @@ public:
     impl_.reset();
   }
 
+  rclcpp::SubscriptionBase::SharedPtr getSubscription() const override
+  {
+    if (impl_) {
+      return impl_->sub_;
+    }
+    return nullptr;
+  }
+
   ///
   /// \brief Decode the given compressed pointcloud into a raw message.
   /// \param[in] compressed The input compressed pointcloud.

--- a/point_cloud_transport/include/point_cloud_transport/subscriber.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/subscriber.hpp
@@ -102,6 +102,10 @@ public:
   POINT_CLOUD_TRANSPORT_PUBLIC
   void shutdown();
 
+  //! Get the underlying ROS subscription handle.
+  POINT_CLOUD_TRANSPORT_PUBLIC
+  rclcpp::SubscriptionBase::SharedPtr getSubscription() const;
+
   operator void *() const;
 
   POINT_CLOUD_TRANSPORT_PUBLIC

--- a/point_cloud_transport/include/point_cloud_transport/subscriber_plugin.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/subscriber_plugin.hpp
@@ -110,6 +110,9 @@ public:
       custom_qos, options);
   }
 
+  /// \brief Get the underlying ROS subscription handle, if available.
+  virtual rclcpp::SubscriptionBase::SharedPtr getSubscription() const = 0;
+
   ///
   /// \brief Subscribe to an pointcloud topic, version for class member function with bare pointer.
   ///

--- a/point_cloud_transport/src/publisher.cpp
+++ b/point_cloud_transport/src/publisher.cpp
@@ -220,12 +220,12 @@ void Publisher::shutdown()
   }
 }
 
-std::vector<rclcpp::PublisherBase::SharedPtr> Publisher::getPublishers() const
+std::map<std::string, rclcpp::PublisherBase::SharedPtr> Publisher::getPublishers() const
 {
   if (impl_) {
-    std::vector<rclcpp::PublisherBase::SharedPtr> pubs;
+    std::map<std::string, rclcpp::PublisherBase::SharedPtr> pubs;
     for (const auto & pub : impl_->publishers_) {
-      pubs.push_back(pub->getPublisher());
+      pubs[pub->getTransportName()] = pub->getPublisher();
     }
     return pubs;
   }

--- a/point_cloud_transport/src/publisher.cpp
+++ b/point_cloud_transport/src/publisher.cpp
@@ -220,6 +220,18 @@ void Publisher::shutdown()
   }
 }
 
+std::vector<rclcpp::PublisherBase::SharedPtr> Publisher::getPublishers() const
+{
+  if (impl_) {
+    std::vector<rclcpp::PublisherBase::SharedPtr> pubs;
+    for (const auto & pub : impl_->publishers_) {
+      pubs.push_back(pub->getPublisher());
+    }
+    return pubs;
+  }
+  return {};
+}
+
 Publisher::operator void *() const
 {
   return (impl_ && impl_->isValid()) ? reinterpret_cast<void *>(1) : reinterpret_cast<void *>(0);

--- a/point_cloud_transport/src/subscriber.cpp
+++ b/point_cloud_transport/src/subscriber.cpp
@@ -159,6 +159,14 @@ void Subscriber::shutdown()
   }
 }
 
+rclcpp::SubscriptionBase::SharedPtr Subscriber::getSubscription() const
+{
+  if (impl_) {
+    return impl_->subscriber_->getSubscription();
+  }
+  return nullptr;
+}
+
 Subscriber::operator void *() const
 {
   return (impl_ && impl_->isValid()) ? reinterpret_cast<void *>(1) : reinterpret_cast<void *>(0);


### PR DESCRIPTION
### Problem

It might be necessary to access the original `rclcpp::Subscriber` or `rclcpp::Publisher` that is hidden behind the abstraction layer with `point_cloud_transport::Subscriber` and `point_cloud_transport::Publisher`. 

### Solution

This PR adds public methods `point_cloud_transport::Subscriber::getSubscription()` and `point_cloud_transport::Publisher::getPublishers()` to access the underlying original subscriber and publishers regardless of the transport plugin, which is used.

### Why I needed this

I needed this to access the [`rclcpp::SubscriptionBase::get_subscription_handle()`](https://docs.ros2.org/bouncy/api/rclcpp/classrclcpp_1_1_subscription_base.html#a819a46b4c3ffba9bef8d05ad7eab7344) and [rclcpp::PublisherBase::get_publisher_handle()](https://docs.ros2.org/crystal/api/rclcpp/classrclcpp_1_1PublisherBase.html#a1ce0fc46bef83e105bea10b772b861ff) functions, which were not accessible when using `point_cloud_transport`.  This is required to add a `TRACEPOINT` that need to be [added to annotate the message flow](https://github.com/christophebedard/ros2-message-flow-test-cases/blob/844c48b543134f2ce1bca1ebb08aac7086418bec/include/ros2_message_flow_testcases/partial_sync_n_to_m.hpp#L84) (e.g. one output message depending on multiple input messages) for `ros2_tracing` so that it can be visualized using Eclipse Trace Compass.