### PR TITLE
Fix exit crash on aarch64 by using leaky singleton for global loader

### DIFF
--- a/point_cloud_transport/src/point_cloud_transport.cpp
+++ b/point_cloud_transport/src/point_cloud_transport.cpp
@@ -74,8 +74,11 @@ PointCloudTransportLoader::~PointCloudTransportLoader()
 {
 }
 
-static std::unique_ptr<PointCloudTransportLoader> kImpl =
-  std::make_unique<PointCloudTransportLoader>();
+static PointCloudTransportLoader & get_loader()
+{
+  static PointCloudTransportLoader * loader = new PointCloudTransportLoader();
+  return *loader;
+}
 
 Publisher create_publisher(
   std::shared_ptr<rclcpp::Node> node,
@@ -83,8 +86,8 @@ Publisher create_publisher(
   rmw_qos_profile_t custom_qos,
   const rclcpp::PublisherOptions & options)
 {
-  return Publisher(*node, base_topic, kImpl->getPubLoader(),
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+  return Publisher(*node, base_topic, get_loader().getPubLoader(),
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
 }
 
 Publisher create_publisher(
@@ -97,8 +100,8 @@ Publisher create_publisher(
   rmw_qos_profile_t custom_qos,
   const rclcpp::PublisherOptions & options)
 {
-  return Publisher(*node_interfaces, base_topic, kImpl->getPubLoader(),
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+  return Publisher(*node_interfaces, base_topic, get_loader().getPubLoader(),
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
 }
 
 Publisher create_publisher(
@@ -111,7 +114,7 @@ Publisher create_publisher(
   rclcpp::QoS custom_qos,
   const rclcpp::PublisherOptions & options)
 {
-  return Publisher(node_interfaces, base_topic, kImpl->getPubLoader(), custom_qos, options);
+  return Publisher(node_interfaces, base_topic, get_loader().getPubLoader(), custom_qos, options);
 }
 
 Subscriber create_subscription(
@@ -124,8 +127,8 @@ Subscriber create_subscription(
 {
   return Subscriber(
     *node, base_topic, callback,
-    kImpl->getSubLoader(), transport,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+    get_loader().getSubLoader(), transport,
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
 }
 
 Subscriber create_subscription(
@@ -142,8 +145,8 @@ Subscriber create_subscription(
 {
   return Subscriber(
     *node_interfaces, base_topic, callback,
-    kImpl->getSubLoader(), transport,
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
+    get_loader().getSubLoader(), transport,
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos), options);
 }
 
 Subscriber create_subscription(
@@ -160,7 +163,7 @@ Subscriber create_subscription(
 {
   return Subscriber(
     node_interfaces, base_topic, callback,
-    kImpl->getSubLoader(), transport, custom_qos, options);
+    get_loader().getSubLoader(), transport, custom_qos, options);
 }
 
 std::vector<std::string> PointCloudTransportLoader::getDeclaredTransports() const
@@ -206,11 +209,8 @@ SubLoaderPtr PointCloudTransportLoader::getSubscriberLoader() const
   return sub_loader_;
 }
 
-thread_local std::unique_ptr<point_cloud_transport::PointCloudTransportLoader> loader;
-
 PointCloudTransport::PointCloudTransport(rclcpp::Node::SharedPtr node)
 {
-  PointCloudTransportLoader();
   node_interfaces_ = rclcpp::node_interfaces::NodeInterfaces<
     rclcpp::node_interfaces::NodeBaseInterface,
     rclcpp::node_interfaces::NodeParametersInterface,
@@ -232,7 +232,6 @@ PointCloudTransport::PointCloudTransport(
     rclcpp::node_interfaces::NodeLoggingInterface> node_interfaces)
 : node_interfaces_(node_interfaces)
 {
-  PointCloudTransportLoader();
 }
 
 }  // namespace point_cloud_transport


### PR DESCRIPTION
## Description

This PR fixes a fatal crash ('corrupted double-linked list') that occurs during process exit, specifically observed on aarch64.

### The Problem
The issue was a classic static destruction order fiasco across shared libraries. The `point_cloud_transport` library maintained a global `static std::unique_ptr<PointCloudTransportLoader> kImpl`, which owned `pluginlib::ClassLoader` objects. During process shutdown, `libclass_loader.so` was occasionally being destroyed/unloaded before `libpoint_cloud_transport.so`. When `kImpl` was finally destroyed, it would call the `ClassLoader` destructors, which in turn attempted to access already-freed internal tracking structures in `libclass_loader.so`, leading to a `heap-use-after-free` and a `SIGABRT`.

### The Fix
1.  **Leaky Singleton**: Converted the global `unique_ptr` to a leaky function-local static pointer (`new` without `delete`). This ensures the `ClassLoader` objects (and the shared libraries they manage) survive until the operating system cleans up the process, bypassing the problematic destruction order.
2.  **Remove unused `thread_local`**: Removed an unused `thread_local` loader which could also contribute to exit-time instability.
3.  **Fix redundant constructor calls**: Cleaned up the `PointCloudTransport` constructors which were redundantly calling the base class constructor in their bodies.

Verified on `amd64` using AddressSanitizer, which consistently caught the `heap-use-after-free` without this fix and passes cleanly with it.

Fixes https://github.com/ros-perception/point_cloud_transport/issues/154

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
Yes. Gemini CLI:2.0-Flash [web_fetch, run_shell_command, replace, git, gh]
