### PR TITLE
Fixed PointCloudCodec encode/decode in Python

### DIFF
--- a/point_cloud_transport_py/src/point_cloud_transport_py/pybind_codec.cpp
+++ b/point_cloud_transport_py/src/point_cloud_transport_py/pybind_codec.cpp
@@ -135,7 +135,7 @@ PYBIND11_MODULE(_codec, m)
       if (success) {
         serializedMsgToString(serialized_msg, serialized_buffer);
       }
-      return serialized_buffer;
+      return py::bytes(serialized_buffer);
     }
   )
   .def(
@@ -153,7 +153,7 @@ PYBIND11_MODULE(_codec, m)
       if (success) {
         pointCloud2ToString(msg, buffer);
       }
-      return buffer;
+      return py::bytes(buffer);
     }
   );
 }


### PR DESCRIPTION
```py
from sensor_msgs.msg import PointCloud2, PointField
from point_cloud_transport_py import PointCloudCodec
from point_cloud_transport_py.common import pointCloud2ToString
codec = PointCloudCodec()
raw = PointCloud2()
raw.fields = [PointField(name='x', datatype=7, count=1), PointField(name='y', datatype=7, count=1, offset=4), PointField(name='z', datatype=7, count=1, offset=8)]
raw.width = 1
raw.height = 1
raw.point_step = 12
raw.row_step = 12
raw.is_bigendian = True
raw.is_dense = True
raw.data = bytes(12 * [0])
codec.encode("raw", pointCloud2ToString(raw))
```

Without this fix, I get:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 58: invalid start byte
```

This PR fixes it and the result is:

```
>>> codec.encode("raw", pointCloud2ToString(raw))
b'\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00x\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00y\x00Q\x81\x04\x00\x00\x00\x07\xf2\x9b\x03\x01\x00\x00\x00\x02\x00\x00\x00z\x00\x00\x00\x08\x00\x00\x00\x07\x00\x00\x00\x01\x00\x00\x00\x01\x7f\x00\x00\x0c\x00\x00\x00\x0c\x00\x00\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
```