### PR TITLE
Make VoidPtr public in PointCloudTransport class

### DIFF
--- a/point_cloud_transport/include/point_cloud_transport/point_cloud_transport.hpp
+++ b/point_cloud_transport/include/point_cloud_transport/point_cloud_transport.hpp
@@ -140,9 +140,9 @@ Subscriber create_subscription(
 /// to create publishers and subscriptions of PointCloud2 topics.
 class PointCloudTransport : public PointCloudTransportLoader
 {
+public:
   using VoidPtr = std::shared_ptr<void>;
 
-public:
   //! Constructor
   POINT_CLOUD_TRANSPORT_PUBLIC
   explicit PointCloudTransport(


### PR DESCRIPTION
VoidPtr is used in public functions like `subscribe()` so it doesn't make sense to hide it.